### PR TITLE
Unify terminal prompt format in apps: terminal and jupyterlab

### DIFF
--- a/user-console/notebook/jupyter-lab-cpu/README.md
+++ b/user-console/notebook/jupyter-lab-cpu/README.md
@@ -10,9 +10,9 @@ Jupyter Lab (CPU) 仅配置了 CPU。如要使用 Nvidia GPU，请切换到 [Jup
 
 | 名称                                              | 环境             |
 | ------------------------------------------------- | ---------------- |
-| `t9kpublic/torch-2.1.0-notebook:1.78.8`           | PyTorch 2, conda |
-| `t9kpublic/tensorflow-2.14.0-notebook-cpu:1.78.8` | TensorFlow 2     |
-| `t9kpublic/miniconda-22.11.1-notebook:1.78.8`     | conda            |
+| `t9kpublic/torch-2.1.0-notebook:20240716`           | PyTorch 2, conda |
+| `t9kpublic/tensorflow-2.14.0-notebook-cpu:20240716` | TensorFlow 2     |
+| `t9kpublic/miniconda-22.11.1-notebook:20240716`     | conda            |
 
 每个镜像包含特定的机器学习框架，同时预装了一些 Python 包、命令行工具和最新版本的平台工具。
 

--- a/user-console/notebook/jupyter-lab-cpu/config.yaml
+++ b/user-console/notebook/jupyter-lab-cpu/config.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: notebook
-          image: t9kpublic/torch-2.1.0-notebook:1.78.8
+          image: t9kpublic/torch-2.1.0-notebook:20240716
           volumeMounts:
             - name: workingdir
               mountPath: /t9k/mnt

--- a/user-console/notebook/jupyter-lab-gpu/README.md
+++ b/user-console/notebook/jupyter-lab-gpu/README.md
@@ -10,9 +10,9 @@ Jupyter Lab (Nvidia GPU) 额外配置了 Nvidia GPU，你可以在其中进行 N
 
 | 名称                                              | 环境             |
 | ------------------------------------------------- | ---------------- |
-| `t9kpublic/torch-2.1.0-notebook:1.78.8`           | PyTorch 2, conda |
-| `t9kpublic/tensorflow-2.14.0-notebook-gpu:1.78.8` | TensorFlow 2     |
-| `t9kpublic/miniconda-22.11.1-notebook:1.78.8`     | conda            |
+| `t9kpublic/torch-2.1.0-notebook:20240716`           | PyTorch 2, conda |
+| `t9kpublic/tensorflow-2.14.0-notebook-gpu:20240716` | TensorFlow 2     |
+| `t9kpublic/miniconda-22.11.1-notebook:20240716`     | conda            |
 
 每个镜像包含特定的机器学习框架，同时预装了一些 Python 包、命令行工具和最新版本的平台工具。
 

--- a/user-console/notebook/jupyter-lab-gpu/config.yaml
+++ b/user-console/notebook/jupyter-lab-gpu/config.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: notebook
-          image: t9kpublic/torch-2.1.0-notebook:1.78.8
+          image: t9kpublic/torch-2.1.0-notebook:20240716
           volumeMounts:
             - name: workingdir
               mountPath: /t9k/mnt

--- a/user-console/terminal/chart/Chart.yaml
+++ b/user-console/terminal/chart/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.1
+appVersion: 0.1.3

--- a/user-console/terminal/chart/templates/deployment.yaml
+++ b/user-console/terminal/chart/templates/deployment.yaml
@@ -2,21 +2,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: terminal-{{ .Release.Name }}
-  name: terminal-{{ .Release.Name }}
+    app: {{ .Release.Name }}
+  name: {{ .Release.Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: terminal-{{ .Release.Name }}
+      app: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: terminal-{{ .Release.Name }}
+        app: {{ .Release.Name }}
     spec:
       containers:
         - name: terminal
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - ttyd
           - -p

--- a/user-console/terminal/chart/templates/service.yaml
+++ b/user-console/terminal/chart/templates/service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: terminal-{{ .Release.Name }}
-  name: terminal-{{ .Release.Name }}
+    app: {{ .Release.Name }}
+  name: {{ .Release.Name }}
 spec:
   ports:
   - name: http
@@ -15,5 +15,5 @@ spec:
     targetPort: 8080
   {{- end }}
   selector:
-    app: terminal-{{ .Release.Name }}
+    app: {{ .Release.Name }}
   type: ClusterIP

--- a/user-console/terminal/chart/templates/virtualservice.yaml
+++ b/user-console/terminal/chart/templates/virtualservice.yaml
@@ -2,8 +2,8 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   labels:
-    app: terminal-{{ .Release.Name }}
-  name: terminal-{{ .Release.Name }}
+    app: {{ .Release.Name }}
+  name: {{ .Release.Name }}
 spec:
   gateways:
   - project-gateway
@@ -21,7 +21,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: terminal-{{ .Release.Name }}
+        host: {{ .Release.Name }}
         port:
           number: 8080
   {{- if not .Values.global.t9k.securityService.enabled }}

--- a/user-console/terminal/docker/Dockerfile
+++ b/user-console/terminal/docker/Dockerfile
@@ -94,6 +94,8 @@ RUN wget https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz \
 RUN sh -c "$(wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+ENV PS1='\[\e[1;32m\][${PWD} \u@\h]\n\$ \[\e[0m\]'
+RUN echo -e "export PROMPT=$'%F{green}%B[%~ %n@%m]\\n%# %b%f'" >> ~/.zshrc
 
 # vim +PluginInstall +qall && vim +GoInstallBinaries &&
 # or using ttyd -p 8080 bash

--- a/user-console/terminal/template.yaml
+++ b/user-console/terminal/template.yaml
@@ -23,7 +23,7 @@ template:
         - group: apps
           version: v1
           resource: deployments
-          name: terminal-{{ .Release.Name }}
+          name: "{{ .Release.Name }}"
           currentStatus: "{{- range .status.conditions }}{{- if eq .type \"Available\" }}{{- .status }}{{- end }}{{- end }}"
           desiredStatus: "True"
       dependencies:


### PR DESCRIPTION
统一 Terminal 中 PROMPT 格式，目前还有一点区别：

JupyterLab：
<img width="447" alt="Screen Shot 2024-07-16 at 18 43 44" src="https://github.com/user-attachments/assets/e8985d5e-40f9-4ab5-912a-8753fbb5cc50">

Terminal Bash：
<img width="482" alt="Screen Shot 2024-07-16 at 18 44 05" src="https://github.com/user-attachments/assets/205d29fe-5353-4a13-ac8e-3920b44b4788">

Terminal Zsh：
<img width="481" alt="Screen Shot 2024-07-16 at 18 53 35" src="https://github.com/user-attachments/assets/ef04b98b-f224-444f-a4c8-dabe6c048bd7">

JupyterLab 的 `(base)` 不知道是在哪一步加进去的（kejie 测试可能和 conda 有关），对 Terminal App 来说 `(base)` 没有意义，就没有加