### PR TITLE
Add function: set param[required] comment if the field is required

### DIFF
--- a/user-console/explorer/codeserver/configs/v0_1_2.yaml
+++ b/user-console/explorer/codeserver/configs/v0_1_2.yaml
@@ -1,2 +1,2 @@
-## @param pvc Select a pvc as CodeServer workspace.
+## @param[required] pvc Select a pvc as CodeServer workspace.
 pvc: ""

--- a/user-console/explorer/filebrowser/configs/v0_1_2.yaml
+++ b/user-console/explorer/filebrowser/configs/v0_1_2.yaml
@@ -1,2 +1,2 @@
-## @param pvc Select a pvc as FileBrowser workspace.
+## @param[required] pvc Select a pvc as FileBrowser workspace.
 pvc: ""

--- a/user-console/notebook/jupyter-lab-cpu/configs/v0_1_1.yaml
+++ b/user-console/notebook/jupyter-lab-cpu/configs/v0_1_1.yaml
@@ -9,7 +9,7 @@ image:
   tag: "20240716"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-cpu/configs/v0_1_2.yaml
+++ b/user-console/notebook/jupyter-lab-cpu/configs/v0_1_2.yaml
@@ -9,7 +9,7 @@ image:
   tag: "20240716"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-dcu/configs/v0_1_1.yaml
+++ b/user-console/notebook/jupyter-lab-dcu/configs/v0_1_1.yaml
@@ -9,7 +9,7 @@ image:
   tag: "240708-dcu"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-dcu/configs/v0_1_2.yaml
+++ b/user-console/notebook/jupyter-lab-dcu/configs/v0_1_2.yaml
@@ -9,7 +9,7 @@ image:
   tag: "240708-dcu"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-gcu/configs/v0_1_1.yaml
+++ b/user-console/notebook/jupyter-lab-gcu/configs/v0_1_1.yaml
@@ -9,7 +9,7 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-gcu/configs/v0_1_2.yaml
+++ b/user-console/notebook/jupyter-lab-gcu/configs/v0_1_2.yaml
@@ -9,7 +9,7 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-gpu/configs/v0_1_1.yaml
+++ b/user-console/notebook/jupyter-lab-gpu/configs/v0_1_1.yaml
@@ -9,7 +9,7 @@ image:
   tag: "20240716"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/jupyter-lab-gpu/configs/v0_1_2.yaml
+++ b/user-console/notebook/jupyter-lab-gpu/configs/v0_1_2.yaml
@@ -9,7 +9,7 @@ image:
   tag: "20240716"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/rstudio/configs/v0_1_1.yaml
+++ b/user-console/notebook/rstudio/configs/v0_1_1.yaml
@@ -9,7 +9,7 @@ image:
   tag: "1.72.1"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.

--- a/user-console/notebook/rstudio/configs/v0_1_2.yaml
+++ b/user-console/notebook/rstudio/configs/v0_1_2.yaml
@@ -9,7 +9,7 @@ image:
   tag: "1.72.1"
   pullPolicy: IfNotPresent
 
-## @param pvc Mount a pvc as notebook working directory.
+## @param[required] pvc Mount a pvc as notebook working directory.
 pvc: ""
 
 ## @param resources.cpu The maximum number of CPU the notebook can use.


### PR DESCRIPTION
说明：以 jupyter-lab-cpu app 为例，image.repository 不是必填字段，因为在 Helm Default Values 中已经有该字段了，所以在部署 App 时，用户就算不填写该字段，依然可以正常部署 App。所以必填字段的标准是：在部署 App 时，如果一个字段不填写会带来错误，则该字段是必填字段。

本修改需要与 https://gitlab.dev.tensorstack.net/t9k/user-console/merge_requests/53 配合使用，否则前端将无法识别该字段。（之前的 Web 不兼容新的 App Config 注释）