### PR TITLE
Update t9k apps to support custom registry

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -190,6 +190,8 @@ global:
 4. `$(T9K_APP_AUTH_CLINET_ID)`：表示一个 Client ID（OAuth 协议中的概念），需要授权的应用应使用该 Client ID 向授权服务器申请授权。
 5. `$(T9K_HOME_DOMAIN)`：平台的域名。
 6. `$(T9K_AUTH_DOMAIN)`：平台授权服务所在域名。
+7. `$(T9K_APP_IMAGE_REGISTRY)`：安装 APP 时，拉取镜像的 Registry 地址。
+8. `$(T9K_APP_IMAGE_NAMESPACE)`：安装 APP 时，拉取镜像的命名空间或者项目。
 
 ## App 运行检测
 

--- a/user-console/autotune/chart/Chart.yaml
+++ b/user-console/autotune/chart/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/user-console/autotune/chart/README.md
+++ b/user-console/autotune/chart/README.md
@@ -32,15 +32,18 @@ cluster:
 
 ### 参数
 
-| 名称                                     | 描述                                                                                  | 值                                            |
-| ---------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `authorization.enabled`                  | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 AutoTune 应用。 | `true`                                        |
-| `authorization.clientID`                 | Oauth2 ClientID                                                                       | `t9k-client`                                  |
-| `authorization.pepProxy.image`           | PEP Proxy 镜像。                                                                      | `docker.io/t9kpublic/pep-proxy:1.0.12`        |
-| `authorization.pepProxy.imagePullPolicy` | PEP Proxy 镜像拉去策略。                                                              | `Always`                                      |
-| `network.gateway`                        |                                                                                       | `project-gateway`                             |
-| `network.domain.home`                    | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                            | `https://home.sample.t9kcloud.cn`             |
-| `network.domain.auth`                    | T9K 平台的授权域名。                                                                  | `https://auth.sample.t9kcloud.cn`             |
-| `imagePullPolicy`                        | 镜像拉取策略。                                                                        | `Always`                                      |
-| `image`                                  | App 镜像。                                                                            | `docker.io/t9kpublic/autotune-app:240822`     |
-| `cluster.extendedResources.gpu`          | 集群所支持的 GPU 扩展资源。                                                           | `["nvidia.com/gpu.shared", "nvidia.com/gpu"]` |
+| 名称                                      | 描述                                                                               | 值                                            |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------- |
+| `authorization.enabled`                   | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 AutoTune 应用。 | `true`                                        |
+| `authorization.clientID`                  | Oauth2 ClientID                                                                    | `t9k-client`                                  |
+| `authorization.pepProxy.image`            | PEP Proxy 镜像。                                                                   |                                               |
+| `authorization.pepProxy.image.registry`   | PEP Proxy 镜像注册表。                                                             | `docker.io`                                   |
+| `authorization.pepProxy.image.repository` | PEP Proxy 镜像仓库。                                                               | `t9kpublic/pep-proxy`                         |
+| `authorization.pepProxy.image.tag`        | PEP Proxy 镜像标签。                                                               | `1.0.12`                                      |
+| `authorization.pepProxy.imagePullPolicy`  | PEP Proxy 镜像拉取策略。                                                           | `Always`                                      |
+| `network.gateway`                         |                                                                                    | `project-gateway`                             |
+| `network.domain.home`                     | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                         | `https://home.sample.t9kcloud.cn`             |
+| `network.domain.auth`                     | T9K 平台的授权域名。                                                               | `https://auth.sample.t9kcloud.cn`             |
+| `imagePullPolicy`                         | 镜像拉取策略。                                                                     | `Always`                                      |
+| `image`                                   | App 镜像。                                                                         | `docker.io/t9kpublic/autotune-app:240822`     |
+| `cluster.extendedResources.gpu`           | 集群所支持的 GPU 扩展资源。                                                        | `["nvidia.com/gpu.shared", "nvidia.com/gpu"]` |

--- a/user-console/autotune/chart/templates/web.deploy.yaml.tmpl
+++ b/user-console/autotune/chart/templates/web.deploy.yaml.tmpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: autotune
-        image: {{ .Values.image }}
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
           - name: http
             containerPort: 8080
@@ -42,7 +42,7 @@ spec:
         - --oidc-issuer-url={{ .Values.network.domain.auth }}/auth/realms/t9k-realm
         - --security-server-address={{ .Values.network.domain.home }}/t9k/security/server
         - --pep-config=/t9kconfig/pep-config.yaml
-        image: {{ .Values.authorization.pepProxy.image }}
+        image: {{ .Values.authorization.pepProxy.image.registry }}/{{ .Values.authorization.pepProxy.image.repository }}:{{ .Values.authorization.pepProxy.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: pep-proxy
         ports:

--- a/user-console/autotune/chart/values.yaml
+++ b/user-console/autotune/chart/values.yaml
@@ -2,7 +2,10 @@ authorization:
   enabled: true
   clientID: "t9k-client"
   pepProxy:
-    image: "docker.io/t9kpublic/pep-proxy:1.0.12"
+    image:
+      registry: "docker.io"
+      repository: "t9kpublic/pep-proxy"
+      tag: "1.0.12"
     imagePullPolicy: Always
 
 network:
@@ -13,7 +16,10 @@ network:
 
 serviceAccount: default
 imagePullPolicy: IfNotPresent
-image: "docker.io/t9kpublic/autotune-app:240822"
+image:
+  registry: "docker.io"
+  repository: "t9kpublic/autotune-app"
+  tag: "240822"
 
 cluster:
   extendedResources:

--- a/user-console/autotune/configs/v0_1_2.yaml
+++ b/user-console/autotune/configs/v0_1_2.yaml
@@ -14,13 +14,7 @@ authorization:
       repository: "$(T9K_APPS_IMAGE_NAMESPACE)/pep-proxy"
       tag: "1.0.12"
 
-server:
-  image:
-    registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-    repository: "$(T9K_APPS_IMAGE_NAMESPACE)/job-manager-server"
-    tag: "240805"
-web:
-  image:
-    registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-    repository: "$(T9K_APPS_IMAGE_NAMESPACE)/job-manager-web"
-    tag: "240805"
+image:
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/autotune-app"
+  tag: "240822"

--- a/user-console/autotune/template.yaml
+++ b/user-console/autotune/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: autotune
   displayName: AutoTune
-  defaultVersion: 0.1.1
+  defaultVersion: 0.1.2
   categories: ["Tool", "AI"]
   description: "AutoTune 是一个自动化机器学习 （AutoML）工具。"
   icon: "file://$APP_DIR/icon.png"
@@ -12,8 +12,8 @@ template:
     repo: "oci://docker.io/t9kpublic"
     chart: "autotune"
     versions:
-    - version: 0.1.1
-      config: "file://$APP_DIR/configs/v0_1_1.yaml"
+    - version: 0.1.2
+      config: "file://$APP_DIR/configs/v0_1_2.yaml"
       urls: 
       - name: autotune
         url: /apps/{{ .Release.Namespace }}/autotune/{{ .Release.Name }}/

--- a/user-console/job-manager/chart/README.md
+++ b/user-console/job-manager/chart/README.md
@@ -31,18 +31,24 @@ cluster:
 
 ### 参数
 
-| 名称                                     | 描述                                                                                  | 值                                              |
-| ---------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `authorization.enabled`                  | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 Job Manager 服务。 | `true`                                          |
-| `authorization.clientID`                 | Oauth2 ClientID                                                                       | `t9k-client`                                    |
-| `authorization.pepProxy.image`           | PEP Proxy 镜像。                                                                      | `docker.io/t9kpublic/pep-proxy:1.0.12`          |
-| `authorization.pepProxy.imagePullPolicy` | PEP Proxy 镜像拉去策略。                                                              | `Always`                                        |
-| `network.gateway`                        |                                                                                       | `project-gateway`                               |
-| `network.domain.home`                    | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                            | `https://home.sample.t9kcloud.cn`              |
-| `network.domain.auth`                    | T9K 平台的授权域名。                                                                  | `https://auth.sample.t9kcloud.cn`              |
-| `server.serviceAccount`                  | Job Manager 服务器所使用的 ServiceAccount。                                           | `managed-project-sa`                            |
-| `server.imagePullPolicy`                 | Job Manager 服务器镜像拉取策略。                                                      | `Always`                                        |
-| `server.image`                           | Job Manager 服务器镜像。                                                              | `docker.io/t9kpublic/job-manager-server:240715` |
-| `web.imagePullPolicy`                    | Job Manager Web 镜像拉取策略。                                                        | `Always`                                        |
-| `web.image`                              | Job Manager Web 镜像。                                                                | `docker.io/t9kpublic/job-manager-web:240715`    |
-| `cluster.extendedResources.gpu`          | 集群所支持的 GPU 扩展资源。                                                           | `["nvidia.com/gpu.shared", "nvidia.com/gpu"]`   |
+| 名称                                      | 描述                                                                                  | 值                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `authorization.enabled`                   | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 Job Manager 服务。 | `true`                                        |
+| `authorization.clientID`                  | Oauth2 ClientID                                                                       | `t9k-client`                                  |
+| `authorization.pepProxy.image`            | PEP Proxy 镜像。                                                                      |                                               |
+| `authorization.pepProxy.image.registry`   | PEP Proxy 镜像注册表。                                                                | `docker.io`                                   |
+| `authorization.pepProxy.image.repository` | PEP Proxy 镜像仓库。                                                                  | `t9kpublic/pep-proxy`                         |
+| `authorization.pepProxy.image.tag`        | PEP Proxy 镜像标签。                                                                  | `1.0.12`                                      |
+| `authorization.pepProxy.imagePullPolicy`  | PEP Proxy 镜像拉取策略。                                                              | `Always`                                      |
+| `network.gateway`                         |                                                                                       | `project-gateway`                             |
+| `network.domain.home`                     | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                            | `https://home.sample.t9kcloud.cn`             |
+| `network.domain.auth`                     | T9K 平台的授权域名。                                                                  | `https://auth.sample.t9kcloud.cn`             |
+| `server.serviceAccount`                   | Job Manager 服务器所使用的 ServiceAccount。                                           | `managed-project-sa`                          |
+| `server.imagePullPolicy`                  | Job Manager 服务器镜像拉取策略。                                                      | `Always`                                      |
+| `server.image`                            | Job Manager 服务器镜像。                                                              |                                               |
+| `server.image.registry`                   | Job Manager 服务器镜像注册表。                                                        | `docker.io`                                   |
+| `server.image.repository`                 | Job Manager 服务器镜像仓库。                                                          | `t9kpublic/job-manager-server`                |
+| `server.image.tag`                        | Job Manager 服务器镜像标签。                                                          | `240715`                                      |
+| `web.imagePullPolicy`                     | Job Manager Web 镜像拉取策略。                                                        | `Always`                                      |
+| `web.image`                               | Job Manager Web 镜像。                                                                | `docker.io/t9kpublic/job-manager-web:240715`  |
+| `cluster.extendedResources.gpu`           | 集群所支持的 GPU 扩展资源。                                                           | `["nvidia.com/gpu.shared", "nvidia.com/gpu"]` |

--- a/user-console/job-manager/configs/v0_2_1.yaml
+++ b/user-console/job-manager/configs/v0_2_1.yaml
@@ -10,17 +10,17 @@ cluster:
 authorization:
   pepProxy:
     image:
-      registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-      repository: "$(T9K_APPS_IMAGE_NAMESPACE)/pep-proxy"
+      registry: "$(T9K_APP_IMAGE_REGISTRY)"
+      repository: "$(T9K_APP_IMAGE_NAMESPACE)/pep-proxy"
       tag: "1.0.12"
 
 server:
   image:
-    registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-    repository: "$(T9K_APPS_IMAGE_NAMESPACE)/job-manager-server"
+    registry: "$(T9K_APP_IMAGE_REGISTRY)"
+    repository: "$(T9K_APP_IMAGE_NAMESPACE)/job-manager-server"
     tag: "240805"
 web:
   image:
-    registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-    repository: "$(T9K_APPS_IMAGE_NAMESPACE)/job-manager-web"
+    registry: "$(T9K_APP_IMAGE_REGISTRY)"
+    repository: "$(T9K_APP_IMAGE_NAMESPACE)/job-manager-web"
     tag: "240805"

--- a/user-console/job-manager/template.yaml
+++ b/user-console/job-manager/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: job-manager
   displayName: Job Manager
-  defaultVersion: 0.2.0
+  defaultVersion: 0.2.1
   categories: ["Tool", "AI"]
   description: "Job Manager 是一个用于管理 T9k Job 的控制台，通过直观的界面方便用户创建 Job、查看 Job 的详细信息以及监控计算资源的使用情况"
   icon: "file://$APP_DIR/icon.svg"

--- a/user-console/notebook/jupyter-lab-cpu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-cpu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: docker.io
-  repository: t9kpublic/torch-2.1.0-notebook
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
   tag: "20240716"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/jupyter-lab-cpu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-cpu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
   tag: "20240716"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/jupyter-lab-dcu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-dcu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "registry.cn-hangzhou.aliyuncs.com"
-  repository: "t9k/jupyterlab-torch-2.1.0"
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/jupyterlab-torch-2.1.0"
   tag: "240708-dcu"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/jupyter-lab-dcu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-dcu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/jupyterlab-torch-2.1.0"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/jupyterlab-torch-2.1.0"
   tag: "240708-dcu"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/jupyter-lab-gpu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-gpu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: docker.io
-  repository: t9kpublic/torch-2.1.0-notebook
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
   tag: "20240716"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/jupyter-lab-gpu/configs/v0_2_0.yaml
+++ b/user-console/notebook/jupyter-lab-gpu/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/torch-2.1.0-notebook"
   tag: "20240716"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/rstudio/configs/v0_1_2.yaml
+++ b/user-console/notebook/rstudio/configs/v0_1_2.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: docker.io
-  repository: t9kpublic/rocker-4.2.3-rstudio
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/rocker-4.2.3-rstudio"
   tag: "1.72.1"
   pullPolicy: IfNotPresent
 

--- a/user-console/notebook/rstudio/configs/v0_1_2.yaml
+++ b/user-console/notebook/rstudio/configs/v0_1_2.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/rocker-4.2.3-rstudio"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/rocker-4.2.3-rstudio"
   tag: "1.72.1"
   pullPolicy: IfNotPresent
 

--- a/user-console/tensorboard/configs/v0_2_0.yaml
+++ b/user-console/tensorboard/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/tensorflow-2.11.0"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/tensorflow-2.11.0"
   tag: "cpu-sdk-0.5.2"
   pullPolicy: IfNotPresent
 

--- a/user-console/tensorboard/configs/v0_2_0.yaml
+++ b/user-console/tensorboard/configs/v0_2_0.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: docker.io
-  repository: t9kpublic/tensorflow-2.11.0
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/tensorflow-2.11.0"
   tag: "cpu-sdk-0.5.2"
   pullPolicy: IfNotPresent
 

--- a/user-console/terminal/chart/Chart.yaml
+++ b/user-console/terminal/chart/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/user-console/terminal/chart/README.md
+++ b/user-console/terminal/chart/README.md
@@ -60,5 +60,12 @@ global:
 | `global.t9k.securityService.enabled`                 | 启用身份认证后，只有当前项目的成员才可以使用该 Terminal。                      | `true`                                    |
 | `global.t9k.securityService.endpoint.oidc`           | 身份认证所需要的 OIDC 服务地址。                                               | `$(T9K_OIDC_ENDPOINT)`                    |
 | `global.t9k.securityService.endpoint.securityServer` | TensorStack 平台的 Security Console 服务器地址。                               | `$(T9K_SECURITY_CONSOLE_SERVER_ENDPOINT)` |
-| `global.t9k.pepProxy.image`                          | PEP Proxy 镜像。                                                               | `docker.io/t9kpublic/pep-proxy:1.0.10`    |
+| `image`                                              | Terminal 镜像。                                                                |                                           |
+| `image.registry`                                     | Terminal 镜像注册表。                                                          | `docker.io`                               |
+| `image.repository`                                   | Terminal 镜像仓库。                                                            | `t9kpublic/terminal`                      |
+| `image.tag`                                          | Terminal 镜像标签。                                                            | `240819`                                  |
+| `global.t9k.pepProxy.image`                          | PEP Proxy 镜像。                                                               |                                           |
+| `global.t9k.pepProxy.image.registry`                 | PEP Proxy 镜像注册表。                                                         | `docker.io`                               |
+| `global.t9k.pepProxy.image.repository`               | PEP Proxy 镜像。                                                               | `t9kpublic/pep-proxy`                     |
+| `global.t9k.pepProxy.image.tag`                      | PEP Proxy 镜像。                                                               | `1.0.12`                                  |
 | `global.t9k.pepProxy.args.clientID`                  | Terminal 使用该 Client ID 向授权服务器申请授权。                               | `$(T9K_APP_AUTH_CLINET_ID)`               |

--- a/user-console/terminal/chart/templates/deployment.yaml
+++ b/user-console/terminal/chart/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - --redirect-url={{ .Values.global.t9k.homeURL }}/apps/{{ .Release.Namespace }}/terminal/{{ .Release.Name }}/oauth2/callback
           - --oidc-issuer-url={{ .Values.global.t9k.securityService.endpoints.oidc }}
           - --pep-config=/t9kconfig/pep-config.yaml
-          image: {{ .Values.global.t9k.pepProxy.image }}
+          image: {{ .Values.global.t9k.pepProxy.image.registry }}/{{ .Values.global.t9k.pepProxy.image.repository }}:{{ .Values.global.t9k.pepProxy.image.tag }}
           imagePullPolicy: IfNotPresent
           name: pep-proxy
           ports:

--- a/user-console/terminal/chart/values.yaml
+++ b/user-console/terminal/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
-  registry: docker.io
-  repository: t9kpublic/terminal
+  registry: "docker.io"
+  repository: "t9kpublic/terminal"
   tag: "240819"
   pullPolicy: IfNotPresent
 
@@ -30,6 +30,9 @@ global:
         oidc: ""
         securityServer: ""
     pepProxy:
-      image: "docker.io/t9kpublic/pep-proxy:1.0.12"
+      image:
+        registry: "docker.io"
+        repository: "t9kpublic/pep-proxy"
+        tag: "1.0.12"
       args:
         clientID: ""

--- a/user-console/terminal/configs/v0_2_1.yaml
+++ b/user-console/terminal/configs/v0_2_1.yaml
@@ -4,8 +4,8 @@
 ## @param image.pullPolicy Image pull policy for the Docker image
 ##
 image:
-  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/terminal"
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/terminal"
   tag: "240819"
   pullPolicy: IfNotPresent
 
@@ -33,8 +33,8 @@ global:
         securityServer: "$(T9K_SECURITY_CONSOLE_SERVER_ENDPOINT)"
     pepProxy:
       image:
-        registry: "$(T9K_APPS_IMAGE_REGISTRY)"
-        repository: "$(T9K_APPS_IMAGE_NAMESPACE)/pep-proxy"
+        registry: "$(T9K_APP_IMAGE_REGISTRY)"
+        repository: "$(T9K_APP_IMAGE_NAMESPACE)/pep-proxy"
         tag: "1.0.12"
       args:
         clientID: $(T9K_APP_AUTH_CLINET_ID)

--- a/user-console/terminal/configs/v0_2_1.yaml
+++ b/user-console/terminal/configs/v0_2_1.yaml
@@ -1,0 +1,40 @@
+## @param image.registry Repository registry for the Docker image
+## @param image.repository Repository name for the Docker image
+## @param image.tag Image tag for the Docker image (immutable tags are recommended)
+## @param image.pullPolicy Image pull policy for the Docker image
+##
+image:
+  registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+  repository: "$(T9K_APPS_IMAGE_NAMESPACE)/terminal"
+  tag: "240819"
+  pullPolicy: IfNotPresent
+
+# sh, bash or zsh
+## @param shell Select a shell to start terminal.
+shell: bash
+
+## @param resources.limits.cpu The maximum number of CPU the terminal can use.
+## @param resources.limits.memory The maximum number of memory the terminal can use.
+resources:
+  limits:
+    cpu: 200m
+    memory: 400Mi
+
+## @param pvcs Mount pvcs to terminal.
+pvcs: []
+
+global:
+  t9k:
+    homeURL: "$(T9K_HOME_URL)"
+    securityService:
+      enabled: true
+      endpoints:
+        oidc: "$(T9K_OIDC_ENDPOINT)"
+        securityServer: "$(T9K_SECURITY_CONSOLE_SERVER_ENDPOINT)"
+    pepProxy:
+      image:
+        registry: "$(T9K_APPS_IMAGE_REGISTRY)"
+        repository: "$(T9K_APPS_IMAGE_NAMESPACE)/pep-proxy"
+        tag: "1.0.12"
+      args:
+        clientID: $(T9K_APP_AUTH_CLINET_ID)

--- a/user-console/terminal/template.yaml
+++ b/user-console/terminal/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: terminal
   displayName: Terminal
-  defaultVersion: "0.2.0"
+  defaultVersion: "0.2.1"
   categories: ["Tool"]
   description: "Terminal 是一个在浏览器中直接打开和操作的集群终端，便于管理集群。"
   icon: "file://$APP_DIR/icon.png"
@@ -13,26 +13,8 @@ template:
     # repo: "https://t9k.github.io/apps/"
     chart: "terminal"
     versions:
-    - version: 0.2.0
-      config: "file://$APP_DIR/configs/v0_2_0.yaml"
-      urls: 
-      - name: terminal
-        url: /apps/{{ .Release.Namespace }}/terminal/{{ .Release.Name }}/
-      readinessProbe:
-        resources:
-        - group: apps
-          version: v1
-          resource: deployments
-          name: "{{ .Release.Name }}"
-          currentStatus: "{{- range .status.conditions }}{{- if eq .type \"Available\" }}{{- .status }}{{- end }}{{- end }}"
-          desiredStatus: "True"
-      dependencies:
-        crds:
-        - group: networking.istio.io
-          version: v1beta1
-          resource: virtualservices
-    - version: 0.1.5
-      config: "file://$APP_DIR/configs/v0_1_5.yaml"
+    - version: 0.2.1
+      config: "file://$APP_DIR/configs/v0_2_1.yaml"
       urls: 
       - name: terminal
         url: /apps/{{ .Release.Namespace }}/terminal/{{ .Release.Name }}/

--- a/user-console/workflow/chart/Chart.yaml
+++ b/user-console/workflow/chart/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/user-console/workflow/chart/README.md
+++ b/user-console/workflow/chart/README.md
@@ -27,17 +27,22 @@ app:
   imagePullPolicy: IfNotPresent
 ```
 
-
 ### 参数
 
-| 名称                                     | 描述                                                                                  | 值                                            |
-| ---------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `authorization.enabled`                  | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 Workflow 应用。 | `true`                                        |
-| `authorization.clientID`                 | Oauth2 ClientID                                                                       | `t9k-client`                                  |
-| `authorization.pepProxy.image`           | PEP Proxy 镜像。                                                                      | `docker.io/t9kpublic/pep-proxy:1.0.12`        |
-| `authorization.pepProxy.imagePullPolicy` | PEP Proxy 镜像拉去策略。                                                              | `IfNotPresent`                                |
-| `network.gateway`                        |                                                                                       | `project-gateway`                             |
-| `network.domain.home`                    | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                            | `https://home.sample.t9kcloud.cn`             |
-| `network.domain.auth`                    | T9K 平台的授权域名。                                                                  | `https://auth.sample.t9kcloud.cn`             |
-| `app.image`                                  | App 镜像。                                                                            | `docker.io/t9kpublic/workflow-app:240830`     |
-| `app.imagePullPolicy`                        | 镜像拉取策略。                                                                        | `IfNotPresent`                                      |
+| 名称                                      | 描述                                                                               | 值                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------- |
+| `authorization.enabled`                   | 是否启用访问验证，在启用访问验证后，只有具有项目权限的人才可以访问 Workflow 应用。 | `true`                            |
+| `authorization.clientID`                  | Oauth2 ClientID                                                                    | `t9k-client`                      |
+| `authorization.pepProxy.image`            | PEP Proxy 镜像。                                                                   |                                   |
+| `authorization.pepProxy.image.registry`   | PEP Proxy 镜像注册表。                                                             | `docker.io`                       |
+| `authorization.pepProxy.image.repository` | PEP Proxy 镜像仓库。                                                               | `t9kpublic/pep-proxy`             |
+| `authorization.pepProxy.image.tag`        | PEP Proxy 镜像标签。                                                               | `1.0.12`                          |
+| `authorization.pepProxy.imagePullPolicy`  | PEP Proxy 镜像拉取策略。                                                           | `IfNotPresent`                    |
+| `network.gateway`                         |                                                                                    | `project-gateway`                 |
+| `network.domain.home`                     | T9K 平台的 Home 域名，App 启动后，用户通过该域名访问服务。                         | `https://home.sample.t9kcloud.cn` |
+| `network.domain.auth`                     | T9K 平台的授权域名。                                                               | `https://auth.sample.t9kcloud.cn` |
+| `app.image`                               | App 镜像。                                                                         |                                   |
+| `app.image.registry`                      | App 镜像注册表。                                                                   | `docker.io`                       |
+| `app.image.repository`                    | App 镜像仓库。                                                                     | `t9kpublic/workflow-app`          |
+| `app.image.tag`                           | App 镜像标签。                                                                     | `240830`                          |
+| `app.imagePullPolicy`                     | 镜像拉取策略。                                                                     | `IfNotPresent`                    |

--- a/user-console/workflow/chart/templates/server.deploy.yaml.tmpl
+++ b/user-console/workflow/chart/templates/server.deploy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: workflow-server
-        image: {{ .Values.app.image }}
+        image: {{ .Values.app.image.registry }}/{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
         command: ["/app/workflow-server"]
         args:
           - "--show-error-trace"
@@ -54,7 +54,7 @@ spec:
         - --oidc-issuer-url={{ .Values.network.domain.auth }}/auth/realms/t9k-realm
         - --pep-config=/t9kconfig/pep-config.yaml
         - --pass-authorization-header
-        image: {{ .Values.authorization.pepProxy.image }}
+        image: {{ .Values.authorization.pepProxy.image.registry }}/{{ .Values.authorization.pepProxy.image.repository }}:{{ .Values.authorization.pepProxy.image.tag }}
         imagePullPolicy: {{ .Values.app.imagePullPolicy }}
         name: pep-proxy
         ports:

--- a/user-console/workflow/chart/templates/web.deploy.yaml.tmpl
+++ b/user-console/workflow/chart/templates/web.deploy.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: workflow-web
-        image: {{ .Values.app.image }}
+        image: {{ .Values.app.image.registry }}/{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
         command: ["/app/spa-server"]
         ports:
           - name: http
@@ -46,7 +46,7 @@ spec:
         - --oidc-issuer-url={{ .Values.network.domain.auth }}/auth/realms/t9k-realm
         - --security-server-address={{ .Values.network.domain.home }}/t9k/security/server
         - --pep-config=/t9kconfig/pep-config.yaml
-        image: {{ .Values.authorization.pepProxy.image }}
+        image: {{ .Values.authorization.pepProxy.image.registry }}/{{ .Values.authorization.pepProxy.image.repository }}:{{ .Values.authorization.pepProxy.image.tag }}
         imagePullPolicy: {{ .Values.app.imagePullPolicy }}
         name: pep-proxy
         ports:

--- a/user-console/workflow/chart/values.yaml
+++ b/user-console/workflow/chart/values.yaml
@@ -2,7 +2,10 @@ authorization:
   enabled: true
   clientID: "t9k-client"
   pepProxy:
-    image: "docker.io/t9kpublic/pep-proxy:1.0.12"
+    image: 
+      registry: "docker.io"
+      repository: "t9kpublic/pep-proxy"
+      tag: "1.0.12"
     imagePullPolicy: IfNotPresent
 
 network:
@@ -13,7 +16,10 @@ network:
 
 app:
   serviceAccount: managed-project-sa
-  image: "docker.io/t9kpublic/workflow-app:240830"
+  image: 
+    registry: "docker.io"
+    repository: "t9kpublic/workflow-app"
+    tag: "240830"
   imagePullPolicy: IfNotPresent
 
 docs: "https://t9k.github.io/ucman/latest/api/workflow/index.html"

--- a/user-console/workflow/configs/v0_1_2.yaml
+++ b/user-console/workflow/configs/v0_1_2.yaml
@@ -3,10 +3,6 @@ network:
     home: "$(T9K_HOME_DOMAIN)"
     auth: "$(T9K_AUTH_DOMAIN)"
 
-cluster:
-  extendedResources:
-    gpu: ["nvidia.com/gpu.shared", "nvidia.com/gpu"]
-
 authorization:
   pepProxy:
     image:
@@ -14,7 +10,8 @@ authorization:
       repository: "$(T9K_APP_IMAGE_NAMESPACE)/pep-proxy"
       tag: "1.0.12"
 
-image:
-  registry: "$(T9K_APP_IMAGE_REGISTRY)"
-  repository: "$(T9K_APP_IMAGE_NAMESPACE)/autotune-app"
-  tag: "240822"
+app:
+  image:
+    registry: "$(T9K_APP_IMAGE_REGISTRY)"
+    repository: "$(T9K_APP_IMAGE_NAMESPACE)/workflow-app"
+    tag: "240830"

--- a/user-console/workflow/template.yaml
+++ b/user-console/workflow/template.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: workflow
   displayName: Workflow
-  defaultVersion: 0.1.1
+  defaultVersion: 0.1.2
   categories: ["Tool", "AI"]
   description: "Workflow 是一个用于管理工作流的控制台，可执行创建工作流、查看运行状态等操作。"
   icon: "file://$APP_DIR/icon.svg"
@@ -12,8 +12,8 @@ template:
     repo: "oci://docker.io/t9kpublic"
     chart: "workflow"
     versions:
-    - version: 0.1.1
-      config: "file://$APP_DIR/configs/v0_1_1.yaml"
+    - version: 0.1.2
+      config: "file://$APP_DIR/configs/v0_1_2.yaml"
       urls: 
       - name: workflow
         url: /apps/{{ .Release.Namespace }}/workflow/{{ .Release.Name }}/web/


### PR DESCRIPTION
修改了所有 T9k 维护的 APP，使得它们支持自定义镜像仓库的安装。

包括以下 APP：

1.  autotune
2. explorer
3. job-manager（主要在上一个 pr 中修改，本次进行了一些调整）
4. notebook
5. tensorboard
6. terminal
7. workflow

并进行了相关测试：

1. 将修改后的 helm chart 上传到 docker.io/t9kpublic 以及 registry.t9kcloud.cn/t9kcharts
2. 运行脚本，将需要使用的镜像上传到 registry.cn-hangzhou.aliyuncs.com/t9k
3. 在远程测试集群注册了相应的 APP。