### PR TITLE
Update label-studio and postgresql to support custom registry

### DIFF
--- a/user-console/label-studio/chart/templates/NOTES.txt
+++ b/user-console/label-studio/chart/templates/NOTES.txt
@@ -2,4 +2,4 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
-Code Server 地址：<T9K_HOME_DOMAIN>/apps/{{ .Release.Namespace }}/label-studio/{{ .Release.Name }}/
+Label Studio 地址：<T9K_HOME_DOMAIN>/apps/{{ .Release.Namespace }}/label-studio/{{ .Release.Name }}/

--- a/user-console/label-studio/chart/templates/NOTES.txt
+++ b/user-console/label-studio/chart/templates/NOTES.txt
@@ -1,40 +1,5 @@
-{{- if .Values.ci }}
-{{- if not (hasKey .Values.global.extraEnvironmentVars "LABEL_STUDIO_HOST") }}
-LABEL_STUDIO_HOST=http{{ if $.Values.app.ingress.tls }}s{{ end }}://{{ .Values.app.ingress.host }}{{ default "" .Values.app.contextPath }}
-{{- else }}
-LABEL_STUDIO_HOST={{ .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST }}
-{{- end }}
-{{- else }}
-Get the application URL by running these commands:
-{{- if .Values.app.ingress.enabled }}
-{{- if not (hasKey .Values.global.extraEnvironmentVars "LABEL_STUDIO_HOST") }}
-Please visit http{{ if $.Values.app.ingress.tls }}s{{ end }}://{{ .Values.app.ingress.host }}{{ default "" .Values.app.contextPath }} to use Label Studio
-{{- else }}
-Please visit {{ .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST }} to use Label Studio
-{{- end }}
-{{- else if contains "NodePort" .Values.app.service.type }}
-After running these commands, please visit http://$NODE_IP:$NODE_PORT to use Label Studio:
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ls-app.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-{{- else if contains "LoadBalancer" .Values.app.service.type }}
-After running these commands, please visit http://$SERVICE_IP:{{ .Values.app.service.port }} to use Label Studio:
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "ls-app.fullname" . }}'
-
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ls-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-{{- else if contains "ClusterIP" .Values.app.service.type }}
-After running these commands, please visit http://127.0.0.1:8080 to use Label Studio:
-
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "ls-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[1].ports[0].containerPort}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
-{{ include "ls.deprecations" . }}
-{{ include "ls.checkConfig" . }}
-{{- if and (not .Values.app.ingress.enabled) (not (hasKey .Values.global.extraEnvironmentVars "LABEL_STUDIO_HOST")) -}}
-     WARNING:
-       If `.Values.app.ingress.enabled` set to `false`, please define `.Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST` instead.
-       It should include http/https scheme and a hostname or IP, e.g.: http://host.com or http://127.0.0.1:8080
-{{- end -}}
-{{- end }}
+Code Server 地址：<T9K_HOME_DOMAIN>/apps/{{ .Release.Namespace }}/label-studio/{{ .Release.Name }}/

--- a/user-console/mongodb/configs/v14_13_0.yaml
+++ b/user-console/mongodb/configs/v14_13_0.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+global:
+  storageClass: ""
+
+## Bitnami MongoDB(&reg;) image
+## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
+## @param image.registry [default: REGISTRY_NAME] MongoDB(&reg;) image registry
+## @param image.repository [default: REPOSITORY_NAME/mongodb] MongoDB(&reg;) image registry
+## @skip image.tag MongoDB(&reg;) image tag (immutable tags are recommended)
+## @param image.digest MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy MongoDB(&reg;) image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Set to true if you would like to see extra information on logs
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/mongodb"
+  tag: 7.0.6-debian-12-r0
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/mongodb/configs/v15_6_1.yaml
+++ b/user-console/mongodb/configs/v15_6_1.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+global:
+  storageClass: ""
+
+## Bitnami MongoDB(&reg;) image
+## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
+## @param image.registry [default: REGISTRY_NAME] MongoDB(&reg;) image registry
+## @param image.repository [default: REPOSITORY_NAME/mongodb] MongoDB(&reg;) image registry
+## @skip image.tag MongoDB(&reg;) image tag (immutable tags are recommended)
+## @param image.digest MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy MongoDB(&reg;) image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Set to true if you would like to see extra information on logs
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/mongodb"
+  tag: 7.0.11-debian-12-r0
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/mongodb/template.yaml
+++ b/user-console/mongodb/template.yaml
@@ -8,11 +8,12 @@ metadata:
   icon: "file://$APP_DIR/icon.svg"
 template:
   helm:
-    repo: "https://charts.bitnami.com/bitnami"
+    repo: "oci://docker.io/t9kpublic"
     chart: "mongodb"
     versions:
     - version: 15.6.1
       urls: []
+      config: "file://$APP_DIR/configs/v15_6_1.yaml"
       readinessProbe:
         resources:
         - group: apps
@@ -24,17 +25,7 @@ template:
       dependencies: {}
     - version: 14.13.0
       urls: []
-      readinessProbe:
-        resources:
-        - group: apps
-          version: v1
-          resource: deployments
-          name: "{{ .Release.Name }}"
-          currentStatus: "{{- range .status.conditions }}{{- if eq .type \"Available\" }}{{- .status }}{{- end }}{{- end }}"
-          desiredStatus: "True"
-      dependencies: {}
-    - version: 13.18.5
-      urls: []
+      config: "file://$APP_DIR/configs/v14_13_0.yaml"
       readinessProbe:
         resources:
         - group: apps

--- a/user-console/mysql/configs/v11_1_20.yaml
+++ b/user-console/mysql/configs/v11_1_20.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
+global:
+  defaultStorageClass: ""
+
+## Bitnami MySQL image
+## ref: https://hub.docker.com/r/bitnami/mysql/tags/
+## @param image.registry [default: REGISTRY_NAME] MySQL image registry
+## @param image.repository [default: REPOSITORY_NAME/mysql] MySQL image repository
+## @skip image.tag MySQL image tag (immutable tags are recommended)
+## @param image.digest MySQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy MySQL image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Specify if debug logs should be enabled
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/mysql"
+  tag: 8.4.3-debian-12-r0
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/mysql/configs/v9_23_0.yaml
+++ b/user-console/mysql/configs/v9_23_0.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
+global:
+  defaultStorageClass: ""
+
+## Bitnami MySQL image
+## ref: https://hub.docker.com/r/bitnami/mysql/tags/
+## @param image.registry [default: REGISTRY_NAME] MySQL image registry
+## @param image.repository [default: REPOSITORY_NAME/mysql] MySQL image repository
+## @skip image.tag MySQL image tag (immutable tags are recommended)
+## @param image.digest MySQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy MySQL image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Specify if debug logs should be enabled
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/mysql"
+  tag: 8.0.36-debian-12-r8
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/mysql/template.yaml
+++ b/user-console/mysql/template.yaml
@@ -8,12 +8,13 @@ metadata:
   icon: "file://$APP_DIR/icon.png"
 template:
   helm:
-    repo: "oci://registry-1.docker.io/bitnamicharts"
+    repo: "oci://docker.io/t9kpublic"
     # repo: "https://charts.bitnami.com/bitnami"
     chart: "mysql"
     versions:
     - version: 11.1.20
       urls: []
+      config: "file://$APP_DIR/configs/v11_1_20.yaml"
       readinessProbe:
         resources:
         - group: apps
@@ -25,6 +26,7 @@ template:
       dependencies: {}
     - version: 9.23.0
       urls: []
+      config: "file://$APP_DIR/configs/v9_23_0.yaml"
       readinessProbe:
         resources:
         - group: apps

--- a/user-console/postgresql/configs/v12_12_10.yaml
+++ b/user-console/postgresql/configs/v12_12_10.yaml
@@ -1,0 +1,72 @@
+## @section Global parameters
+## Please, note that this will override the parameters, including dependencies, configured to use the global value
+global:
+  ## @param global.storageClass Global StorageClass for Persistent Volume(s)
+  storageClass: ""
+
+## Bitnami PostgreSQL image version
+## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
+## @param image.registry [default: REGISTRY_NAME] PostgreSQL image registry
+## @param image.repository [default: REPOSITORY_NAME/postgresql] PostgreSQL image repository
+## @skip image.tag PostgreSQL image tag (immutable tags are recommended)
+## @param image.pullPolicy PostgreSQL image pull policy
+## @param image.pullSecrets Specify image pull secrets
+## @param image.debug Specify if debug values should be set
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/postgresql"
+  tag: 15.4.0-debian-11-r45
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+
+## Authentication parameters
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#setting-the-root-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-user-on-first-run
+##
+auth:
+  ## @param auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
+  ##
+  enablePostgresUser: true
+  ## @param auth.postgresPassword Password for the "postgres" admin user. Ignored if `auth.existingSecret` is provided
+  ##
+  postgresPassword: ""
+  ## @param auth.username Name for a custom user to create
+  ##
+  username: ""
+  ## @param auth.password Password for the custom user to create. Ignored if `auth.existingSecret` is provided
+  ##
+  password: ""
+  ## @param auth.database Name for a custom database to create
+  ##
+  database: ""
+  ## @param auth.replicationUsername Name of the replication user
+  ##
+  replicationUsername: repl_user
+  ## @param auth.replicationPassword Password for the replication user. Ignored if `auth.existingSecret` is provided
+  ##
+  replicationPassword: ""
+  ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
+  ##
+  existingSecret: ""
+  ## @param auth.secretKeys.adminPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ## @param auth.secretKeys.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ## @param auth.secretKeys.replicationPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ##
+  secretKeys:
+    adminPasswordKey: postgres-password
+    userPasswordKey: password
+    replicationPasswordKey: replication-password
+  ## @param auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
+  ##
+  usePasswordFiles: false
+## @param architecture PostgreSQL architecture (`standalone` or `replication`)
+##
+architecture: standalone

--- a/user-console/postgresql/configs/v15_5_15.yaml
+++ b/user-console/postgresql/configs/v15_5_15.yaml
@@ -1,0 +1,71 @@
+## @section Global parameters
+global:
+  ## @param global.storageClass Global StorageClass for Persistent Volume(s)
+  storageClass: ""
+
+## Bitnami PostgreSQL image version
+## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
+## @param image.registry [default: REGISTRY_NAME] PostgreSQL image registry
+## @param image.repository [default: REPOSITORY_NAME/postgresql] PostgreSQL image repository
+## @skip image.tag PostgreSQL image tag (immutable tags are recommended)
+## @param image.pullPolicy PostgreSQL image pull policy
+## @param image.pullSecrets Specify image pull secrets
+## @param image.debug Specify if debug values should be set
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/postgresql"
+  tag: 16.3.0-debian-12-r19
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+
+## Authentication parameters
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#setting-the-root-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-user-on-first-run
+##
+auth:
+  ## @param auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
+  ##
+  enablePostgresUser: true
+  ## @param auth.postgresPassword Password for the "postgres" admin user. Ignored if `auth.existingSecret` is provided
+  ##
+  postgresPassword: ""
+  ## @param auth.username Name for a custom user to create
+  ##
+  username: ""
+  ## @param auth.password Password for the custom user to create. Ignored if `auth.existingSecret` is provided
+  ##
+  password: ""
+  ## @param auth.database Name for a custom database to create
+  ##
+  database: ""
+  ## @param auth.replicationUsername Name of the replication user
+  ##
+  replicationUsername: repl_user
+  ## @param auth.replicationPassword Password for the replication user. Ignored if `auth.existingSecret` is provided
+  ##
+  replicationPassword: ""
+  ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
+  ##
+  existingSecret: ""
+  ## @param auth.secretKeys.adminPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ## @param auth.secretKeys.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ## @param auth.secretKeys.replicationPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
+  ##
+  secretKeys:
+    adminPasswordKey: postgres-password
+    userPasswordKey: password
+    replicationPasswordKey: replication-password
+  ## @param auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
+  ##
+  usePasswordFiles: false
+## @param architecture PostgreSQL architecture (`standalone` or `replication`)
+##
+architecture: standalone

--- a/user-console/postgresql/template.yaml
+++ b/user-console/postgresql/template.yaml
@@ -8,33 +8,13 @@ metadata:
   icon: "file://$APP_DIR/icon.svg"
 template:
   helm:
-    repo: "https://charts.bitnami.com/bitnami"
+    repo: "oci://docker.io/t9kpublic"
+    # repo: "https://t9k.github.io/apps/"
     chart: "postgresql"
     versions:
-    - version: 15.5.0
+    - version: 15.5.15
       urls: []
-      readinessProbe:
-        resources:
-        - group: apps
-          version: v1
-          resource: statefulsets
-          name: "{{ .Release.Name }}"
-          currentStatus: "{{- if ge .status.availableReplicas 1 }}True{{- else }}False{{- end }}"
-          desiredStatus: "True"
-      dependencies: {}
-    - version: 14.3.3
-      urls: []
-      readinessProbe:
-        resources:
-        - group: apps
-          version: v1
-          resource: statefulsets
-          name: "{{ .Release.Name }}"
-          currentStatus: "{{- if ge .status.availableReplicas 1 }}True{{- else }}False{{- end }}"
-          desiredStatus: "True"
-      dependencies: {}
-    - version: 13.4.4
-      urls: []
+      config: "file://$APP_DIR/configs/v15_5_15.yaml"
       readinessProbe:
         resources:
         - group: apps
@@ -46,17 +26,7 @@ template:
       dependencies: {}
     - version: 12.12.10
       urls: []
-      readinessProbe:
-        resources:
-        - group: apps
-          version: v1
-          resource: statefulsets
-          name: "{{ .Release.Name }}"
-          currentStatus: "{{- if ge .status.availableReplicas 1 }}True{{- else }}False{{- end }}"
-          desiredStatus: "True"
-      dependencies: {}
-    - version: 11.9.13
-      urls: []
+      config: "file://$APP_DIR/configs/v12_12_10.yaml"
       readinessProbe:
         resources:
         - group: apps

--- a/user-console/redis/configs/17_17_1.yaml
+++ b/user-console/redis/configs/17_17_1.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+global:
+  storageClass: ""
+
+## Bitnami Redis&reg; image
+## ref: https://hub.docker.com/r/bitnami/redis/tags/
+## @param image.registry [default: REGISTRY_NAME] Redis&reg; image registry
+## @param image.repository [default: REPOSITORY_NAME/redis] Redis&reg; image repository
+## @skip image.tag Redis&reg; image tag (immutable tags are recommended)
+## @param image.digest Redis&reg; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Redis&reg; image pull policy
+## @param image.pullSecrets Redis&reg; image pull secrets
+## @param image.debug Enable image debug mode
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/redis"
+  tag: 7.0.12-debian-11-r34
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/redis/configs/v18_19_4.yaml
+++ b/user-console/redis/configs/v18_19_4.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+global:
+  storageClass: ""
+
+## Bitnami Redis&reg; image
+## ref: https://hub.docker.com/r/bitnami/redis/tags/
+## @param image.registry [default: REGISTRY_NAME] Redis&reg; image registry
+## @param image.repository [default: REPOSITORY_NAME/redis] Redis&reg; image repository
+## @skip image.tag Redis&reg; image tag (immutable tags are recommended)
+## @param image.digest Redis&reg; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Redis&reg; image pull policy
+## @param image.pullSecrets Redis&reg; image pull secrets
+## @param image.debug Enable image debug mode
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/redis"
+  tag: 7.2.4-debian-12-r9
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/redis/configs/v19_5_0.yaml
+++ b/user-console/redis/configs/v19_5_0.yaml
@@ -1,0 +1,35 @@
+## @section Global parameters
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+global:
+  storageClass: ""
+
+## Bitnami Redis&reg; image
+## ref: https://hub.docker.com/r/bitnami/redis/tags/
+## @param image.registry [default: REGISTRY_NAME] Redis&reg; image registry
+## @param image.repository [default: REPOSITORY_NAME/redis] Redis&reg; image repository
+## @skip image.tag Redis&reg; image tag (immutable tags are recommended)
+## @param image.digest Redis&reg; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Redis&reg; image pull policy
+## @param image.pullSecrets Redis&reg; image pull secrets
+## @param image.debug Enable image debug mode
+##
+image:
+  registry: "$(T9K_APP_IMAGE_REGISTRY)"
+  repository: "$(T9K_APP_IMAGE_NAMESPACE)/redis"
+  tag: 7.2.5-debian-12-r0
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false

--- a/user-console/redis/template.yaml
+++ b/user-console/redis/template.yaml
@@ -13,6 +13,7 @@ template:
     versions:
     - version: 19.5.0
       urls: []
+      config: "file://$APP_DIR/configs/v19_5_0.yaml"
       # readinessProbe:
       #   resources:
       #   - group: apps
@@ -24,7 +25,9 @@ template:
       dependencies: {}
     - version: 18.19.4
       urls: []
+      config: "file://$APP_DIR/configs/v18_19_4.yaml"
       dependencies: {}
     - version: 17.17.1
       urls: []
+      config: "file://$APP_DIR/configs/v17_17_1.yaml"
       dependencies: {}


### PR DESCRIPTION
做了以下修改：

1. 去掉 label-studio 的无效说明。因为可以直接通过网页打开，无需额外说明。
2. 为 postgresql App 添加 configs，以支持自定义 registry 的安装。
3. mirror 这两个 App 需要用到的镜像到阿里云，Helm Chart 到 registry.t9kcloud.cn 仓库。